### PR TITLE
Recreate Test Database endpoint

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -59,4 +59,8 @@ export class IntegreSQLApiClient {
   async reuseTestDatabase(hash: string, id: number) {
     return this.request<null>('DELETE', `/templates/${hash}/tests/${id}`)
   }
+
+  async recreateTestDatabase(hash: string, id: number) {
+    return this.request<null>('DELETE', `/templates/${hash}/tests/${id}/recreate`)
+  }
 }

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -61,6 +61,6 @@ export class IntegreSQLApiClient {
   }
 
   async recreateTestDatabase(hash: string, id: number) {
-    return this.request<null>('DELETE', `/templates/${hash}/tests/${id}/recreate`)
+    return this.request<null>('POST', `/templates/${hash}/tests/${id}/recreate`)
   }
 }

--- a/tests/apiClient.spec.ts
+++ b/tests/apiClient.spec.ts
@@ -120,5 +120,14 @@ describe('apiClient', () => {
       expect(response).toEqual(null)
       expect(mockFetch.mock.calls).toMatchSnapshot()
     })
+
+    test('can recreate a test database', async () => {
+      mockFetch.mockImplementation(getMockFetchImplementation(200, ''))
+
+      const response = await client.recreateTestDatabase('mock-hash', 42)
+
+      expect(response).toEqual(null)
+      expect(mockFetch.mock.calls).toMatchSnapshot()
+    })
   })
 })


### PR DESCRIPTION
I was missing the ability to call the recreateTestDatabase endpoint described in the IntegreSQL documentation:
https://github.com/allaboutapps/integresql#optional-manually-recreating-a-test-database