### PR TITLE
fix: replace `path` with `path:posix`

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -1,4 +1,4 @@
-import path from 'path'
+import path from 'path/posix'
 import { createIntegreSQLApiClientError } from './apiClientError'
 import { GetTestDatabaseResponse, InitializeTemplateResponse } from './interfaces'
 


### PR DESCRIPTION
To keep the behavior consistent across OSes
